### PR TITLE
Handle the situation where get_rust_version() returns None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ class build_rust(_build_rust):
     def run(self):
 
         try:
-            nightly = "nightly" in get_rust_version().prerelease
+            rustc = get_rust_version()
+            nightly = rustc.prerelease is not None and "nightly" in rustc.prerelease
         except DistutilsPlatformError:
             if sys.platform in ("linux", "darwin"):
                 self.setup_temp_rustc_unix(toolchain="nightly", profile="minimal")


### PR DESCRIPTION
This patch fixes the following error:

```
Building wheels for collected packages: fastobo
  Building wheel for fastobo (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python /usr/lib/python3.9/site-packages/pep517/_in_process.py build_wheel /tmp/tmptw38d0q7               
       cwd: /tmp/pip-install-sexex2xq/fastobo                                                                                 
  Complete output (44 lines):                                                                                                 
  running bdist_wheel                                                                                                         
  running build                                                                                                               
  running build_ext                                                                                                           
  running build_rust                                                                                                          
  Traceback (most recent call last):                                                                                          
    File "/usr/lib/python3.9/site-packages/pep517/_in_process.py", line 280, in <module>                                      
      main()                                                                                                                  
    File "/usr/lib/python3.9/site-packages/pep517/_in_process.py", line 263, in main                                          
      json_out['return_val'] = hook(**hook_input['kwargs'])                                                                   
    File "/usr/lib/python3.9/site-packages/pep517/_in_process.py", line 204, in build_wheel                                   
      return _build_backend().build_wheel(wheel_directory, config_settings,                                                   
    File "/tmp/pip-build-env-hnfxziji/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 216, in build_wheel 
      return self._build_with_temp_dir(['bdist_wheel'], '.whl',                                                               
    File "/tmp/pip-build-env-hnfxziji/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 202, in _build_with_temp_dir                                                                                                                      
      self.run_setup()                                                                                                        
    File "/tmp/pip-build-env-hnfxziji/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 145, in run_setup   
      exec(compile(code, __file__, 'exec'), locals())                                                                         
    File "setup.py", line 90, in <module>                                                                                     
      setuptools.setup(                                                                                                       
    File "/tmp/pip-build-env-hnfxziji/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup         
      return distutils.core.setup(**attrs)                                                                                    
    File "/usr/lib/python3.9/distutils/core.py", line 148, in setup                                                           
      dist.run_commands()                                                                                                     
    File "/usr/lib/python3.9/distutils/dist.py", line 966, in run_commands                                                    
      self.run_command(cmd)                                                                                                   
    File "/usr/lib/python3.9/distutils/dist.py", line 985, in run_command                                                     
      cmd_obj.run()                                                                                                           
    File "/tmp/pip-build-env-hnfxziji/normal/lib/python3.9/site-packages/wheel/bdist_wheel.py", line 299, in run              
      self.run_command('build')                                                                                               
    File "/usr/lib/python3.9/distutils/cmd.py", line 313, in run_command                                                      
      self.distribution.run_command(command)                                                                                  
    File "/usr/lib/python3.9/distutils/dist.py", line 985, in run_command                                                     
      cmd_obj.run()                                                                                                           
    File "/usr/lib/python3.9/distutils/command/build.py", line 135, in run                                                    
      self.run_command(cmd_name)                                                                                              
    File "/usr/lib/python3.9/distutils/cmd.py", line 313, in run_command                                                      
      self.distribution.run_command(command)                                                                                  
    File "/usr/lib/python3.9/distutils/dist.py", line 985, in run_command                                                     
      cmd_obj.run()                                                                                                           
    File "/tmp/pip-build-env-hnfxziji/overlay/lib/python3.9/site-packages/setuptools_rust/setuptools_ext.py", line 23, in run 
      build_rust.run()                                                                                                        
    File "setup.py", line 39, in run                                                                                          
      nightly = "nightly" in get_rust_version().prerelease                                                                    
  TypeError: argument of type 'NoneType' is not iterable                                                                      
  ----------------------------------------                                                                                    
  ERROR: Failed building wheel for fastobo
Failed to build fastobo
```